### PR TITLE
Fixed minor copy-paste error in ffx_core_hlsl

### DIFF
--- a/sdk/include/FidelityFX/gpu/ffx_core_hlsl.h
+++ b/sdk/include/FidelityFX/gpu/ffx_core_hlsl.h
@@ -292,9 +292,9 @@ FfxInt32x2 ffxBroadcast2(FfxInt32 value)
 /// A 3-dimensional signed integer vector with <c><i>value</i></c> in each component.
 ///
 /// @ingroup HLSLCore
-FfxUInt32x3 ffxBroadcast3(FfxInt32 value)
+FfxInt32x3 ffxBroadcast3(FfxInt32 value)
 {
-    return FfxUInt32x3(value, value, value);
+    return FfxInt32x3(value, value, value);
 }
 
 /// Broadcast a scalar value to a 4-dimensional signed integer vector.


### PR DESCRIPTION
The 32-bit int variant of ffxBroadcast3 returned an FfxUInt32x3, instead of FfxInt32x3