### PR TITLE
Fix FrameInterpolationSwapChainDX12::ResizeBuffers not handling a 0 buffer count properly

### DIFF
--- a/sdk/src/backends/dx12/FrameInterpolationSwapchain/FrameInterpolationSwapchainDX12.cpp
+++ b/sdk/src/backends/dx12/FrameInterpolationSwapchain/FrameInterpolationSwapchainDX12.cpp
@@ -1307,7 +1307,11 @@ HRESULT STDMETHODCALLTYPE FrameInterpolationSwapChainDX12::ResizeBuffers(UINT Bu
     const UINT fiAdjustedFlags = getInterpolationEnabledSwapChainFlags(SwapChainFlags);
 
     // update params expected by the application
-    gameBufferCount_ = BufferCount;
+    // a buffer count of zero means we need to preserve the original count
+    if (BufferCount != 0) 
+    {
+        gameBufferCount_ = BufferCount;
+    }
     gameFlags_       = SwapChainFlags;
 
     HRESULT hr = real()->ResizeBuffers(0 /* preserve count */, Width, Height, NewFormat, fiAdjustedFlags);


### PR DESCRIPTION
Calling ResizeBuffers with BufferCount = 0 means that the original buffer count should be preserved.
Currently this does actually set the game buffer count to zero, causing crashes on subsequent GetBuffer calls.