### PR TITLE
Make UI+Scene composition use pre-multiplied alpha blend

### DIFF
--- a/sdk/src/backends/dx12/FrameInterpolationSwapchain/FrameInterpolationSwapchainUiComposition.hlsl
+++ b/sdk/src/backends/dx12/FrameInterpolationSwapchain/FrameInterpolationSwapchainUiComposition.hlsl
@@ -33,5 +33,6 @@ float4 mainPS(float4 vPosition : SV_POSITION) : SV_Target
     float3 color = r_currBB[vPosition.xy].rgb;
     float4 guiColor = r_uiTexture[vPosition.xy];
 
-    return float4(lerp(color, guiColor.rgb, guiColor.a), 1);
+    // Pre-multiplied alpha formula
+    return float4(guiColor.rgb + (color * (1.f - guiColor.a)), 1);
 }


### PR DESCRIPTION
This might be an questionable change, but most game engines use pre-multiplied alpha to compose the UI on top of the game scene.
I think it's good if FSR3 did the same by default.
There's a chance I misunderstood this code :).