### PR TITLE
Vulkan 1.1 fallback for vkGetBufferMemoryRequirements2KHR 

### DIFF
--- a/sdk/src/backends/vk/ffx_vk.cpp
+++ b/sdk/src/backends/vk/ffx_vk.cpp
@@ -1363,7 +1363,13 @@ FfxErrorCode CreateBackendContextVK(FfxInterface* backendInterface, FfxEffectBin
         backendContext->vkFunctionTable.vkDestroySampler = (PFN_vkDestroySampler)vkDeviceContext->vkDeviceProcAddr(backendContext->device, "vkDestroySampler");
         backendContext->vkFunctionTable.vkDestroyShaderModule = (PFN_vkDestroyShaderModule)vkDeviceContext->vkDeviceProcAddr(backendContext->device, "vkDestroyShaderModule");
         backendContext->vkFunctionTable.vkGetBufferMemoryRequirements = (PFN_vkGetBufferMemoryRequirements)vkDeviceContext->vkDeviceProcAddr(backendContext->device, "vkGetBufferMemoryRequirements");
+        
         backendContext->vkFunctionTable.vkGetBufferMemoryRequirements2KHR = (PFN_vkGetBufferMemoryRequirements2KHR)vkDeviceContext->vkDeviceProcAddr(backendContext->device, "vkGetBufferMemoryRequirements2KHR");
+        
+        // If extension not found try loading it from Core 1.1
+        if (!backendContext->vkFunctionTable.vkGetBufferMemoryRequirements2KHR)
+            backendContext->vkFunctionTable.vkGetBufferMemoryRequirements2KHR = (PFN_vkGetBufferMemoryRequirements2KHR)vkDeviceContext->vkDeviceProcAddr(backendContext->device, "vkGetBufferMemoryRequirements2");
+        
         backendContext->vkFunctionTable.vkGetImageMemoryRequirements = (PFN_vkGetImageMemoryRequirements)vkDeviceContext->vkDeviceProcAddr(backendContext->device, "vkGetImageMemoryRequirements");
         backendContext->vkFunctionTable.vkAllocateDescriptorSets = (PFN_vkAllocateDescriptorSets)vkDeviceContext->vkDeviceProcAddr(backendContext->device, "vkAllocateDescriptorSets");
         backendContext->vkFunctionTable.vkFreeDescriptorSets = (PFN_vkFreeDescriptorSets)vkDeviceContext->vkDeviceProcAddr(backendContext->device, "vkFreeDescriptorSets");
@@ -4031,11 +4037,12 @@ FfxErrorCode ExecuteGpuJobsVK(FfxInterface* backendInterface, FfxCommandList com
     {
         FfxGpuJobDescription* gpuJob = &backendContext->pGpuJobs[i];
 
+#ifdef _DEBUG
         // If we have a label for the job, drop a marker for it
         if (gpuJob->jobLabel[0]) {
             beginMarkerVK(backendContext, vkCommandBuffer, gpuJob->jobLabel);
         }
-
+#endif
         
         switch (gpuJob->jobType)
         {
@@ -4062,9 +4069,11 @@ FfxErrorCode ExecuteGpuJobsVK(FfxInterface* backendInterface, FfxCommandList com
         default:;
         }
 
+#ifdef _DEBUG
         if (gpuJob->jobLabel[0]) {
             endMarkerVK(backendContext, vkCommandBuffer);
         }
+#endif
     }
 
     // check the execute function returned cleanly.


### PR DESCRIPTION
Added Vulkan 1.1 fallback for `vkGetBufferMemoryRequirements2KHR` if extension is not found

Added `ifdef _DEBUG` checks for `beginMarkerVK` and `endMarkerVK` calls