### PR TITLE
Reorder LinkHeaders function to allow compiling on Clang

### DIFF
--- a/ffx-api/include/ffx_api/ffx_api.hpp
+++ b/ffx-api/include/ffx_api/ffx_api.hpp
@@ -56,12 +56,10 @@ namespace detail
     }
 }
 
-template<class First, class Second, class... Rest>
-First* LinkHeaders(First& first, Second& second, Rest&... rest)
+template<class Header>
+Header* LinkHeaders(Header& hdr)
 {
-    first.pNext = &second;
-    LinkHeaders(second, rest...);
-    return &first;
+    return &hdr;
 }
 
 template<class First, class Second>
@@ -72,10 +70,12 @@ First* LinkHeaders(First& first, Second& second)
     return &first;
 }
 
-template<class Header>
-Header* LinkHeaders(Header& hdr)
+template<class First, class Second, class... Rest>
+First* LinkHeaders(First& first, Second& second, Rest&... rest)
 {
-    return &hdr;
+    first.pNext = &second;
+    LinkHeaders(second, rest...);
+    return &first;
 }
 
 template<class... Desc>


### PR DESCRIPTION
Fixes this error in Clang
```
AMD_FidelityFX/include\ffx_api/ffx_api.hpp(63,5): error: call to function 'LinkHeaders' that is neither visible in the template definition nor found by argument-dependent lookup
   63 |     LinkHeaders(second, rest...);
      |     ^
AMD_FidelityFX/include\ffx_api/ffx_api.hpp(63,5): note: in instantiation of function template specialization 'ffx::LinkHeaders<ffxApiHeader, ffxApiHeader>' requested here
AMD_FidelityFX/include\ffx_api/ffx_api.hpp(84,19): note: in instantiation of function template specialization 'ffx::LinkHeaders<ffxApiHeader, ffxApiHeader, ffxApiHeader>' requested here
   84 |     auto header = LinkHeaders(desc.header...);
      |                   ^
AMD_FidelityFX/include\ffx_api/ffx_api.hpp(76,9): note: 'LinkHeaders' should be declared prior to the call site or in the global namespace
   76 | Header* LinkHeaders(Header& hdr)
      |   
```