### PR TITLE
Update ffx_api.h

### DIFF
--- a/Kits/FidelityFX/api/include/ffx_api.h
+++ b/Kits/FidelityFX/api/include/ffx_api.h
@@ -26,7 +26,11 @@
 extern "C" {
 #endif  // #if defined(__cplusplus)
 
-#define FFX_API_ENTRY __declspec(dllexport)
+//For Non-MSVC Compilers
+#ifndef DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
+#endif
+#define FFX_API_ENTRY DLLEXPORT
 
 #include <stdint.h>
 


### PR DESCRIPTION
DllExport Error Edit.

Older Code has Error Occur For Unreal Engine's Cross-Platform Envioment.

Like This.
```
/Myproj/Engine/Plugins/FSR4/Source/fidelityfx-sdk/Kits/FidelityFX/api/include/ffx_api.h:132:1: error: '__declspec' attributes are not enabled; use '-fdeclspec' or '-fms-extensions' to enable support for __declspec attributes
/Myproj/Engine/Plugins/FSR4/Source/fidelityfx-sdk/Kits/FidelityFX/api/include/ffx_api.h:29:23: note: expanded from macro 'FFX_API_ENTRY'
#define FFX_API_ENTRY __declspec(dllexport)
```